### PR TITLE
变更包名；实现字符串调用方法

### DIFF
--- a/console/build.gradle
+++ b/console/build.gradle
@@ -15,7 +15,6 @@ android {
 
 dependencies {
 	compile fileTree(dir: 'libs', include: ['*.jar'])
-	compile project(":storage/emulated/0/AppProjects/Libs/Log/")
 	// runtime目录
 	// 用于放置打包jar根目录classes{N}.dex文件
 	// 也支持资源文件

--- a/console/src/main/java/Main.java
+++ b/console/src/main/java/Main.java
@@ -1,9 +1,0 @@
-import java.util.*;
-
-public class Main
-{
-	public static void main(String[] args)
-	{
-		System.out.println("hello");
-	}
-}

--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/core/MethodHandleExecutor.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/core/MethodHandleExecutor.java
@@ -1,0 +1,114 @@
+package com.goldsprite.methodhandleexecutor.core;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.HashMap;
+import java.util.Map;
+import java.lang.reflect.*;
+
+public class MethodHandleExecutor {
+    private final Map<String, MethodHandle> methodHandles = new HashMap<>();
+
+    public MethodHandleExecutor(Class<?> targetClass) throws Exception {
+        MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+
+        for (Method method : targetClass.getMethods()) {
+            MethodHandle handle = getMethodHandle(lookup, targetClass, method);
+            if (handle != null) {
+                methodHandles.put(method.getName(), handle);
+            }
+        }
+    }
+
+    private MethodHandle getMethodHandle(MethodHandles.Lookup lookup, Class<?> targetClass, Method method) {
+        try {
+            MethodType methodType = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
+            if (Modifier.isStatic(method.getModifiers())) {
+                return lookup.findStatic(targetClass, method.getName(), methodType);
+            } else {
+                return lookup.findVirtual(targetClass, method.getName(), methodType);
+            }
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            // 处理无法找到的方法句柄时的异常
+            System.err.println("Method handle creation failed for: " + method.getName() + " - " + e.getMessage());
+            return null;
+        }
+    }
+
+    public MethodHandle getMethodHandle(String methodName) {
+        return methodHandles.get(methodName);
+    }
+	
+	public Object executeCommand(Object target, String commandLine) throws Throwable {
+		String[] parts = commandLine.split(" ");
+		if (parts.length == 0) {
+			throw new IllegalArgumentException("命令行不能为空");
+		}
+
+		String command = parts[0];
+		MethodHandle handle = getMethodHandle(command);
+		if (handle == null) {
+			throw new NoSuchMethodException("未找到匹配的命令: " + command);
+		}
+
+		// 获取方法签名的参数类型
+		Class<?>[] parameterTypes = handle.type().parameterArray();
+
+		// 判断是否为静态方法（静态方法的第一个参数不会是目标对象的类型）
+		boolean isStatic = parameterTypes.length == 0 || !parameterTypes[0].isInstance(target);
+
+		// 检查参数数量是否匹配
+		int expectedArgsCount = isStatic ? parameterTypes.length : parameterTypes.length - 1;
+		if (parts.length - 1 != expectedArgsCount) {
+			throw new IllegalArgumentException("参数数量不匹配");
+		}
+
+		// 解析参数
+		Object[] args = new Object[expectedArgsCount];
+		for (int i = 0; i < expectedArgsCount; i++) {
+			int argIndex = isStatic ? i + 1 : i + 1;  // 第一个命令部分是方法名，args 从第二部分开始
+			args[i] = parseArgument(parts[argIndex], parameterTypes[i + (isStatic ? 0 : 1)]);
+		}
+
+		// 调用方法
+		return isStatic ? handle.invokeWithArguments(args) : handle.bindTo(target).invokeWithArguments(args);
+	}
+	
+	
+    public Object executeCommand(Object target, String command, Object... args) throws Throwable {
+		MethodHandle handle = getMethodHandle(command);
+		if (handle != null) {
+			if (handle.type().parameterCount() > 0 && handle.type().parameterType(0).isInstance(target)) {
+				// 如果是非静态方法，绑定目标对象
+				return handle.bindTo(target).invokeWithArguments(args);
+			} else {
+				// 静态方法直接调用
+				return handle.invokeWithArguments(args);
+			}
+		} else {
+			throw new NoSuchMethodException("未找到匹配的命令: " + command);
+		}
+	}
+	
+	private Object parseArgument(String arg, Class<?> targetType) {
+		try {
+			if (targetType == Integer.class || targetType == int.class) {
+				return Integer.parseInt(arg);
+			} else if (targetType == Long.class || targetType == long.class) {
+				return Long.parseLong(arg);
+			} else if (targetType == Double.class || targetType == double.class) {
+				return Double.parseDouble(arg);
+			} else if (targetType == Float.class || targetType == float.class) {
+				return Float.parseFloat(arg);
+			} else if (targetType == Boolean.class || targetType == boolean.class) {
+				return Boolean.parseBoolean(arg);
+			}
+		} catch (NumberFormatException ignored) {
+			// 如果解析失败，返回原始字符串
+		}
+		return arg;
+	}
+	
+}
+

--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/Main.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/Main.java
@@ -1,0 +1,20 @@
+package com.goldsprite.methodhandleexecutor.samples;
+import com.goldsprite.methodhandleexecutor.core.*;
+
+public class Main {
+    public static void main(String[] args) {
+        try {
+            MyCommands myCommands = new MyCommands();
+            MethodHandleExecutor executor = new MethodHandleExecutor(MyCommands.class);
+
+            executor.executeCommand(myCommands, "sayHello");
+            executor.executeCommand(myCommands, "staticHello");
+			Object ret = executor.executeCommand(myCommands, "add 3 4");
+			float retNum = (float)ret;
+			System.out.println("返回值: "+retNum);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/MyCommands.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/MyCommands.java
@@ -1,0 +1,16 @@
+package com.goldsprite.methodhandleexecutor.samples;
+
+public class MyCommands {
+    public void sayHello() { // 实例方法
+        System.out.println("Hello!");
+    }
+
+    public static void staticHello() { // 静态方法
+        System.out.println("Static Hello!");
+    }
+	
+	public static float add(float num1, float num2){
+		System.out.printf("%f+%f=%f\n", num1, num2, num1+num2);
+		return num1+num2;
+	}
+}


### PR DESCRIPTION
# V0.1.0

## 更新条目
- 一个样品类用于提供公开方法
    - sayHello 实例方法
    - staticHello 静态方法
    - add(int 数字1, int 数字2) 有参有返回方法
- 创建目标类型的公开句柄执行器
    - getMethodHandle 使用lookup从目标类型与方法获取方法句柄
    - executeCommand 获取对应方法句柄并转换参数以调用
    - parseArgument 将String参数转换为给定的paramType类型
- 通过字符串调用公开句柄方法

## 现有问题
1. isStatic的判断根据参方法参数长度以及target实例equals来判定，在target为null时调用实例方法将错误判断为静态导致异常