### PR TITLE
第二版v0.2.0

### DIFF
--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/core/MethodHandleExecutor.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/core/MethodHandleExecutor.java
@@ -8,58 +8,65 @@ import java.util.Map;
 import java.lang.reflect.*;
 
 public class MethodHandleExecutor {
-    private final Map<String, MethodHandle> methodHandles = new HashMap<>();
+	private final Map<String, MethodHandle> methodHandles = new HashMap<>();
+	private final Map<String, Boolean> methodIsStatic = new HashMap<>();  // 存储方法的静态性
+	private Object target;
 
-    public MethodHandleExecutor(Class<?> targetClass) throws Exception {
-        MethodHandles.Lookup lookup = MethodHandles.publicLookup();
+	public MethodHandleExecutor(Object target) throws Exception {
+		this.target = target;
+		initializeMethodHandles(target.getClass());
+	}
+	public MethodHandleExecutor(Class<?> targetClass) throws Exception {
+		initializeMethodHandles(targetClass);
+	}
+	public void initializeMethodHandles(Class<?> targetClass) throws Exception {
+		MethodHandles.Lookup lookup = MethodHandles.publicLookup();
 
-        for (Method method : targetClass.getMethods()) {
-            MethodHandle handle = getMethodHandle(lookup, targetClass, method);
-            if (handle != null) {
-                methodHandles.put(method.getName(), handle);
-            }
-        }
-    }
+		for (Method method : targetClass.getMethods()) {
+			MethodHandle handle = getMethodHandle(lookup, targetClass, method);
+			if (handle != null) {
+				methodHandles.put(method.getName(), handle);
+				methodIsStatic.put(method.getName(), Modifier.isStatic(method.getModifiers()));  // 记录静态性
+			}
+		}
+	}
 
-    private MethodHandle getMethodHandle(MethodHandles.Lookup lookup, Class<?> targetClass, Method method) {
-        try {
-            MethodType methodType = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
-            if (Modifier.isStatic(method.getModifiers())) {
-                return lookup.findStatic(targetClass, method.getName(), methodType);
-            } else {
-                return lookup.findVirtual(targetClass, method.getName(), methodType);
-            }
-        } catch (NoSuchMethodException | IllegalAccessException e) {
-            // 处理无法找到的方法句柄时的异常
-            System.err.println("Method handle creation failed for: " + method.getName() + " - " + e.getMessage());
-            return null;
-        }
-    }
+	private MethodHandle getMethodHandle(MethodHandles.Lookup lookup, Class<?> targetClass, Method method) {
+		try {
+			MethodType methodType = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
+			if (Modifier.isStatic(method.getModifiers())) {
+				return lookup.findStatic(targetClass, method.getName(), methodType);
+			} else {
+				return lookup.findVirtual(targetClass, method.getName(), methodType);
+			}
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			System.err.println("Method handle creation failed for: " + method.getName() + " - " + e.getMessage());
+			return null;
+		}
+	}
 
-    public MethodHandle getMethodHandle(String methodName) {
-        return methodHandles.get(methodName);
-    }
-	
-	public Object executeCommand(Object target, String commandLine) throws Throwable {
+	public Object executeCommand(String commandLine) throws Throwable {
 		String[] parts = commandLine.split(" ");
 		if (parts.length == 0) {
 			throw new IllegalArgumentException("命令行不能为空");
 		}
 
 		String command = parts[0];
-		MethodHandle handle = getMethodHandle(command);
+		MethodHandle handle = methodHandles.get(command);
+		Boolean isStatic = methodIsStatic.get(command);  // 获取静态性
 		if (handle == null) {
 			throw new NoSuchMethodException("未找到匹配的命令: " + command);
 		}
+		if (isStatic && target == null){
+			throw new NullPointerException("试图从null调用一个实例方法");
+		}
 
-		// 获取方法签名的参数类型
+		// 获取方法的参数类型
 		Class<?>[] parameterTypes = handle.type().parameterArray();
 
-		// 判断是否为静态方法（静态方法的第一个参数不会是目标对象的类型）
-		boolean isStatic = parameterTypes.length == 0 || !parameterTypes[0].isInstance(target);
-
 		// 检查参数数量是否匹配
-		int expectedArgsCount = isStatic ? parameterTypes.length : parameterTypes.length - 1;
+		int paramOffset = !isStatic ?1 : 0;
+		int expectedArgsCount = parameterTypes.length - paramOffset;
 		if (parts.length - 1 != expectedArgsCount) {
 			throw new IllegalArgumentException("参数数量不匹配");
 		}
@@ -67,31 +74,19 @@ public class MethodHandleExecutor {
 		// 解析参数
 		Object[] args = new Object[expectedArgsCount];
 		for (int i = 0; i < expectedArgsCount; i++) {
-			int argIndex = isStatic ? i + 1 : i + 1;  // 第一个命令部分是方法名，args 从第二部分开始
-			args[i] = parseArgument(parts[argIndex], parameterTypes[i + (isStatic ? 0 : 1)]);
+			int argIndex = i + 1;  // 第一个命令部分是方法名，args 从第二部分开始
+			args[i] = parseArgument(parts[argIndex], parameterTypes[i + paramOffset]);
 		}
 
 		// 调用方法
 		return isStatic ? handle.invokeWithArguments(args) : handle.bindTo(target).invokeWithArguments(args);
 	}
-	
-	
-    public Object executeCommand(Object target, String command, Object... args) throws Throwable {
-		MethodHandle handle = getMethodHandle(command);
-		if (handle != null) {
-			if (handle.type().parameterCount() > 0 && handle.type().parameterType(0).isInstance(target)) {
-				// 如果是非静态方法，绑定目标对象
-				return handle.bindTo(target).invokeWithArguments(args);
-			} else {
-				// 静态方法直接调用
-				return handle.invokeWithArguments(args);
-			}
-		} else {
-			throw new NoSuchMethodException("未找到匹配的命令: " + command);
-		}
-	}
-	
+
+	// 辅助方法：解析参数
 	private Object parseArgument(String arg, Class<?> targetType) {
+		if (targetType == String.class) {
+			return arg;
+		}
 		try {
 			if (targetType == Integer.class || targetType == int.class) {
 				return Integer.parseInt(arg);
@@ -109,6 +104,5 @@ public class MethodHandleExecutor {
 		}
 		return arg;
 	}
-	
 }
 

--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/Main.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/Main.java
@@ -2,19 +2,18 @@ package com.goldsprite.methodhandleexecutor.samples;
 import com.goldsprite.methodhandleexecutor.core.*;
 
 public class Main {
-    public static void main(String[] args) {
-        try {
-            MyCommands myCommands = new MyCommands();
-            MethodHandleExecutor executor = new MethodHandleExecutor(MyCommands.class);
+	public static void main(String[] args) {
+		try {
+			MyCommands myCommands = new MyCommands();
+			MethodHandleExecutor executor = new MethodHandleExecutor(myCommands);
 
-            executor.executeCommand(myCommands, "sayHello");
-            executor.executeCommand(myCommands, "staticHello");
-			Object ret = executor.executeCommand(myCommands, "add 3 4");
-			float retNum = (float)ret;
-			System.out.println("返回值: "+retNum);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
-    }
+			executor.executeCommand("sayHello");
+			executor.executeCommand("staticHello");
+			float ret = executor.executeCommand("add 3.1 4");
+			System.out.println("返回值: " + ret);
+		} catch (Throwable e) {
+			e.printStackTrace();
+		}
+	}
 }
 

--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/MyCommands.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/MyCommands.java
@@ -1,16 +1,16 @@
 package com.goldsprite.methodhandleexecutor.samples;
 
 public class MyCommands {
-    public void sayHello() { // 实例方法
-        System.out.println("Hello!");
-    }
+	public void sayHello() { // 实例方法
+		System.out.println("Hello!");
+	}
 
-    public static void staticHello() { // 静态方法
-        System.out.println("Static Hello!");
-    }
-	
+	public static void staticHello() { // 静态方法
+		System.out.println("Static Hello!");
+	}
+
 	public static float add(float num1, float num2){
-		System.out.printf("%f+%f=%f\n", num1, num2, num1+num2);
-		return num1+num2;
+		System.out.printf("%f+%f=%f\n", num1, num2, num1 + num2);
+		return num1 + num2;
 	}
 }


### PR DESCRIPTION
# V0.2.0

## 更新条目
- 一个样品类用于提供公开方法
    - 保持不变
- 创建目标实例或类型的公开句柄执行器
    - 增加isStatic属性 在初始化时直接记录静态类型以保证判断准确性
    - 增加target属性 初始化时选择传入实例或类型，省略了每次传入实例参数
- 通过字符串调用公开句柄方法
    - 无需每次传入实例

## 问题记录
1. isStatic的判断根据参方法参数长度以及target实例equals来判定，在target为null时调用实例方法将错误判断为静态导致异常
    - [x] 解决了静态方法误判的问题
