### PR TITLE
v0.3.0

### DIFF
--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/Main.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/Main.java
@@ -10,7 +10,9 @@ public class Main {
 			executor.executeCommand("sayHello");
 			executor.executeCommand("staticHello");
 			float ret = executor.executeCommand("add 3.1 4");
-			System.out.println("返回值: " + ret);
+			System.out.println("返回值: "+ret);
+			executor.executeCommand("sub 3000000000 5");
+			executor.executeCommand("sub 6.4 5");
 		} catch (Throwable e) {
 			e.printStackTrace();
 		}

--- a/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/MyCommands.java
+++ b/console/src/main/java/com/goldsprite/methodhandleexecutor/samples/MyCommands.java
@@ -8,9 +8,19 @@ public class MyCommands {
 	public static void staticHello() { // 静态方法
 		System.out.println("Static Hello!");
 	}
-
+	
 	public static float add(float num1, float num2){
-		System.out.printf("%f+%f=%f\n", num1, num2, num1 + num2);
-		return num1 + num2;
+		System.out.printf("%f+%f=%f\n", num1, num2, num1+num2);
+		return num1+num2;
+	}
+	
+	public void sub(int num1, int num2){
+		System.out.printf("int: %d-%d=%d\n", num1, num2, num1-num2);
+	}
+	public void sub(long num1, int num2){
+		System.out.printf("long: %d-%d=%d\n", num1, num2, num1-num2);
+	}
+	public void sub(float num1, int num2){
+		System.out.printf("float: %f-%d=%f\n", num1, num2, num1-num2);
 	}
 }


### PR DESCRIPTION
# V0.3.0

## 更新条目
- 一个样品类用于提供公开方法
    - 增加3个不同参数类型的sub方法分别使用int long float与int相减
- 公开句柄执行器
    - methodHandles的value改为List形式，以解决重名方法异常的问题
    - 初始化时将同名method存储为methodName->List
    - 重构了命令解析方式，遍历以尝试从方法列表中匹配符合的方法
    - 增加了覆盖基本数据类型的参数类型转换
- 通过字符串调用公开句柄方法
    - 现在可以调用重名方法
- examples.Main 演示入口
    - 增加sub long int和sub float int的示例，但实际皆被解析为float
## 问题记录
1. 由于宽松parse方法命令可能被错误的解析为意料之外的方法
